### PR TITLE
fix missing comma in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,6 @@ setup(
     url='https://github.com/Open-Argumentation/ArgDB',
     author_email='mail@simonwells.org',
     version='0.1',
-    packages=find_packages(exclude=('deploy', 'etc', 'examples'))
+    packages=find_packages(exclude=('deploy', 'etc', 'examples')),
     install_requires=['tinydb']
 )


### PR DESCRIPTION
This just fixes a missing comma. 

if you try to install ArgDB with pip using Git, it will throw an error. This fixes it.